### PR TITLE
Fixes for Debug build of depending libraries

### DIFF
--- a/examples/synopsis.cpp
+++ b/examples/synopsis.cpp
@@ -18,6 +18,8 @@ class Dolphin : public Animal {};
 
 #include <yorel/yomm2/cute.hpp>
 
+#include <string>
+
 using yorel::yomm2::virtual_;
 
 register_class(Animal);

--- a/src/yomm2.cpp
+++ b/src/yomm2.cpp
@@ -853,7 +853,6 @@ bool runtime::is_base(const rt_spec* a, const rt_spec* b)
     return result;
 }
 
-#if YOMM2_ENABLE_TRACE
 std::ostream* active_log = nullptr;
 
 std::ostream& log() {
@@ -877,7 +876,6 @@ std::ostream* log_off() {
     active_log = nullptr;
     return prev;
 }
-#endif
 
 void default_method_call_error_handler(const method_call_error& error) {
 #if YOMM2_ENABLE_TRACE


### PR DESCRIPTION
Fixes #17.

See #17 for a discussion of the problem.

As an additional change, a missing include was added to an example file. Compilation of said example fails when 
```
target_compile_definitions(yomm2 PUBLIC YOMM2_ENABLE_TRACE=0)
```
is added to the top-level CMakeLists.txt file (since an include was made dependent on `YOMM2_ENABLE_TRACE`).