### PR TITLE
Support shared library builds

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,7 +81,7 @@ IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentCaseLabels: false
 IndentGotoLabels: true
-IndentPPDirectives: None
+IndentPPDirectives: BeforeHash
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,40 @@ jobs:
         run: |
           cd cmake.bld/examples
           find . -type f -executable -exec {} \;
+  ubuntu-shared:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [g++-10, g++-11, clang++-11, clang++-12]
+        standard: [17]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install g++-11
+        if: ${{ matrix.compiler == 'g++-11' }}
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt update
+          sudo apt install g++-11
+      - name: Install Boost
+        run: |
+          sudo apt update
+          sudo apt install libboost-all-dev
+      - name: Configure
+        run: |
+          mkdir cmake.bld
+          cd cmake.bld
+          cmake .. -DYOMM2_SHARED=1 -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.standard }} -DYOMM2_ENABLE_TESTS=1
+      - name: Build
+        run: VERBOSE=1 cmake --build cmake.bld
+      - name: Unit Tests
+        run: |
+          cd cmake.bld
+          ctest --rerun-failed --output-on-failure .
+      - name: Examples
+        run: |
+          pwd
+          cd cmake.bld/examples
+          find . -type f -executable -exec {} \;
   windows:
     runs-on: windows-latest
     strategy:
@@ -94,6 +128,35 @@ jobs:
           mkdir cmake.bld
           cd cmake.bld
           cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_CXX_STANDARD=${{ matrix.standard }} -DYOMM2_ENABLE_TESTS=1
+      - name: Build
+        run: |
+          cd cmake.bld
+          nmake
+      - name: Unit Tests
+        run: |
+          cd cmake.bld
+          $env:YOMM2_TRACE = 1
+          ctest --rerun-failed --output-on-failure .
+          $global:LASTEXITCODE = 0
+      # - name: Examples
+      #   run: |
+      #     cd cmake.bld/examples
+      #     find . -type f -executable -exec {} \;
+      # - name: Benchmarks
+      #   if: ${{ matrix.config == 'Release' }}
+      #   run: |
+      #     cd cmake.bld/tests
+      #     benchmarks
+  windows-shared:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ilammy/msvc-dev-cmd@v1.4.1
+      - name: Configure
+        run: |
+          mkdir cmake.bld
+          cd cmake.bld
+          cmake .. -G "NMake Makefiles" -DYOMM2_SHARED=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DYOMM2_ENABLE_TESTS=1
       - name: Build
         run: |
           cd cmake.bld

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,12 @@ jobs:
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt update
           sudo apt install g++-11
+      - name: Install clang-11
+        if: ${{ matrix.compiler == 'clang++-11' }}
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt update
+          sudo apt install clang-11
       - name: Install Boost
         run: |
           sudo apt update

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ cd build
 cmake ..
 make
 ```
+By default, YOMM2 is built as a static library. It can also be built as a shared
+library by adding `-DYOMM2_SHARED=1` to the `cmake` command line.
 
 If you want to run the tests:
 

--- a/include/yorel/yomm2/core.hpp
+++ b/include/yorel/yomm2/core.hpp
@@ -22,8 +22,6 @@
         #if defined(_WIN32)
             #define yOMM2_API __declspec(dllimport)
         #else
-            #define YOMM2_SYMBOL_EXPORT                                        \
-                __attribute__((__visibility__("default")))
             #define yOMM2_API
         #endif
     #endif

--- a/include/yorel/yomm2/core.hpp
+++ b/include/yorel/yomm2/core.hpp
@@ -8,30 +8,27 @@
 #include <vector>
 
 #if defined(YOMM2_TRACE) && (YOMM2_TRACE & 2)
-#include <iostream>
+    #include <iostream>
 #else
-#include <iosfwd>
+    #include <iosfwd>
 #endif
 
 #include <boost/mp11/algorithm.hpp>
 #include <boost/mp11/bind.hpp>
 #include <boost/type_traits/is_virtual_base_of.hpp>
 
-#if YOMM2_SHARED
-#if defined(_WIN32)
-#define YOMM2_SYMBOL_EXPORT __declspec(dllexport)
-#define YOMM2_SYMBOL_IMPORT __declspec(dllimport)
+#if defined(YOMM2_SHARED)
+    #if !defined(yOMM2_API)
+        #if defined(_WIN32)
+            #define yOMM2_API __declspec(dllimport)
+        #else
+            #define YOMM2_SYMBOL_EXPORT                                        \
+                __attribute__((__visibility__("default")))
+            #define yOMM2_API
+        #endif
+    #endif
 #else
-#define YOMM2_SYMBOL_EXPORT __attribute__((__visibility__("default")))
-#define YOMM2_SYMBOL_IMPORT
-#endif
-#if BUILDING_YOMM2
-#define YOMM2_API YOMM2_SYMBOL_EXPORT
-#else
-#define YOMM2_API YOMM2_SYMBOL_IMPORT
-#endif
-#else
-#define YOMM2_API
+    #define yOMM2_API
 #endif
 
 namespace yorel {
@@ -66,7 +63,7 @@ using error_type =
 
 using error_handler_type = void (*)(const error_type& error);
 
-YOMM2_API error_handler_type set_error_handler(error_handler_type handler);
+yOMM2_API error_handler_type set_error_handler(error_handler_type handler);
 
 struct catalog;
 struct context;
@@ -103,7 +100,7 @@ using method_call_error_handler = void (*)(
     const method_call_error& error, size_t arity,
     const std::type_info* const tis[]);
 
-YOMM2_API method_call_error_handler
+yOMM2_API method_call_error_handler
 set_method_call_error_handler(method_call_error_handler handler);
 
 // end deprecated
@@ -134,11 +131,11 @@ namespace policy {
 
 struct abstract_policy {};
 
-struct YOMM2_API global_context : virtual abstract_policy {
+struct yOMM2_API global_context : virtual abstract_policy {
     static struct context context;
 };
 
-struct YOMM2_API global_catalog : virtual abstract_policy {
+struct yOMM2_API global_catalog : virtual abstract_policy {
     static struct catalog catalog;
 };
 
@@ -153,7 +150,7 @@ struct hash_factors_in_globals : global_catalog, global_context {
 };
 
 struct hash_factors_in_method : global_catalog, global_context {
-    struct YOMM2_API method_info_type : detail::method_info {
+    struct yOMM2_API method_info_type : detail::method_info {
         detail::hash_function hash;
         void install_hash_factors(detail::runtime& rt) override;
     };
@@ -386,7 +383,7 @@ struct class_declaration : detail::class_info {
 template<typename... T>
 using use_classes = typename detail::use_classes_aux<T...>::type;
 
-YOMM2_API void update_methods();
+yOMM2_API void update_methods();
 
 } // namespace yomm2
 } // namespace yorel

--- a/include/yorel/yomm2/core.hpp
+++ b/include/yorel/yomm2/core.hpp
@@ -17,6 +17,23 @@
 #include <boost/mp11/bind.hpp>
 #include <boost/type_traits/is_virtual_base_of.hpp>
 
+#if YOMM2_SHARED
+#if defined(_WIN32)
+#define YOMM2_SYMBOL_EXPORT __declspec(dllexport)
+#define YOMM2_SYMBOL_IMPORT __declspec(dllimport)
+#else
+#define YOMM2_SYMBOL_EXPORT __attribute__((__visibility__("default")))
+#define YOMM2_SYMBOL_IMPORT
+#endif
+#if BUILDING_YOMM2
+#define YOMM2_API YOMM2_SYMBOL_EXPORT
+#else
+#define YOMM2_API YOMM2_SYMBOL_IMPORT
+#endif
+#else
+#define YOMM2_API
+#endif
+
 namespace yorel {
 namespace yomm2 {
 
@@ -49,7 +66,7 @@ using error_type =
 
 using error_handler_type = void (*)(const error_type& error);
 
-error_handler_type set_error_handler(error_handler_type handler);
+YOMM2_API error_handler_type set_error_handler(error_handler_type handler);
 
 struct catalog;
 struct context;
@@ -86,7 +103,7 @@ using method_call_error_handler = void (*)(
     const method_call_error& error, size_t arity,
     const std::type_info* const tis[]);
 
-method_call_error_handler
+YOMM2_API method_call_error_handler
 set_method_call_error_handler(method_call_error_handler handler);
 
 // end deprecated
@@ -117,11 +134,11 @@ namespace policy {
 
 struct abstract_policy {};
 
-struct global_context : virtual abstract_policy {
+struct YOMM2_API global_context : virtual abstract_policy {
     static struct context context;
 };
 
-struct global_catalog : virtual abstract_policy {
+struct YOMM2_API global_catalog : virtual abstract_policy {
     static struct catalog catalog;
 };
 
@@ -136,7 +153,7 @@ struct hash_factors_in_globals : global_catalog, global_context {
 };
 
 struct hash_factors_in_method : global_catalog, global_context {
-    struct method_info_type : detail::method_info {
+    struct YOMM2_API method_info_type : detail::method_info {
         detail::hash_function hash;
         void install_hash_factors(detail::runtime& rt) override;
     };
@@ -369,7 +386,7 @@ struct class_declaration : detail::class_info {
 template<typename... T>
 using use_classes = typename detail::use_classes_aux<T...>::type;
 
-void update_methods();
+YOMM2_API void update_methods();
 
 } // namespace yomm2
 } // namespace yorel

--- a/include/yorel/yomm2/detail.hpp
+++ b/include/yorel/yomm2/detail.hpp
@@ -125,7 +125,7 @@ using type_next_t = decltype(type_next(std::declval<Container>()));
 template<typename Container, typename Next>
 constexpr bool has_next_v = std::is_same_v<type_next_t<Container>, Next>;
 
-extern error_handler_type error_handler;
+extern YOMM2_API error_handler_type error_handler;
 
 struct hash_function {
     std::uintptr_t mult;
@@ -164,7 +164,7 @@ struct definition_info : static_chain<definition_info>::static_link {
     void* pf;
 };
 
-struct method_info : static_chain<method_info>::static_link {
+struct YOMM2_API method_info : static_chain<method_info>::static_link {
     std::string_view name;
     const std::type_info *const *vp_begin, *const *vp_end;
     static_chain<definition_info> specs;
@@ -178,8 +178,7 @@ struct method_info : static_chain<method_info>::static_link {
     detail::word* hash_table;
     detail::word slots_strides; // slot 0, slot 1,  stride 1, slot 2, ...
 
-    virtual void install_hash_factors(runtime&) {
-    }
+    virtual void install_hash_factors(runtime&);
 
     auto arity() const {
         return std::distance(vp_begin, vp_end);

--- a/include/yorel/yomm2/detail.hpp
+++ b/include/yorel/yomm2/detail.hpp
@@ -9,7 +9,7 @@ namespace detail {
 
 struct runtime;
 
-void update_methods(catalog& cat, context& ht);
+yOMM2_API void update_methods(catalog& cat, context& ht);
 
 namespace mp11 = boost::mp11;
 
@@ -125,7 +125,7 @@ using type_next_t = decltype(type_next(std::declval<Container>()));
 template<typename Container, typename Next>
 constexpr bool has_next_v = std::is_same_v<type_next_t<Container>, Next>;
 
-extern YOMM2_API error_handler_type error_handler;
+extern yOMM2_API error_handler_type error_handler;
 
 struct hash_function {
     std::uintptr_t mult;
@@ -164,7 +164,7 @@ struct definition_info : static_chain<definition_info>::static_link {
     void* pf;
 };
 
-struct YOMM2_API method_info : static_chain<method_info>::static_link {
+struct yOMM2_API method_info : static_chain<method_info>::static_link {
     std::string_view name;
     const std::type_info *const *vp_begin, *const *vp_end;
     static_chain<definition_info> specs;

--- a/include/yorel/yomm2/runtime.hpp
+++ b/include/yorel/yomm2/runtime.hpp
@@ -90,7 +90,7 @@ struct rt_method {
     dispatch_stats_t stats;
 };
 
-struct runtime {
+struct YOMM2_API runtime {
 
     catalog& cat;
     context& ctx;

--- a/include/yorel/yomm2/runtime.hpp
+++ b/include/yorel/yomm2/runtime.hpp
@@ -90,7 +90,7 @@ struct rt_method {
     dispatch_stats_t stats;
 };
 
-struct YOMM2_API runtime {
+struct yOMM2_API runtime {
 
     catalog& cat;
     context& ctx;

--- a/reference.in/README.md
+++ b/reference.in/README.md
@@ -89,16 +89,18 @@ This header defines the `yorel::yomm2` namespace, which contains the `method`
 template, and other C++ mechanisms. Since version 1.3.0, the key mechanisms are
 documented; thus, it possible to use the library without resorting on the
 macros. See the [API tutorial](../tutorials/api.md) for an introduction to the
-main feautures of `core`.
-
-The header itself does not define any macros, except for its include guard
-(`YOREL_YOMM2_CORE_INCLUDED`).
+main features of `core`.
 
 The header consumes two macros:
 * `NDEBUG`: if defined, no checks are performed during method calls. This
   delivers a performance close to normal virtual function calls.
 * `YOMM2_TRACE`: controls tracing. This feature is, at the moment, not
   documented.
+* `YOMM2_SHARED`: if defined, the library runtime is in a shared library or DLL.
+
+The header defines the following macros:
+* an include guard (`YOREL_YOMM2_CORE_INCLUDED`).
+* *iff* `YOMM2_SHARED` is defined, a `yOMM2_API` macro, for internal use.
 
 ### `<yorel/yomm2/symbols.hpp>`
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -89,16 +89,18 @@ This header defines the `yorel::yomm2` namespace, which contains the `method`
 template, and other C++ mechanisms. Since version 1.3.0, the key mechanisms are
 documented; thus, it possible to use the library without resorting on the
 macros. See the [API tutorial](../tutorials/api.md) for an introduction to the
-main feautures of `core`.
-
-The header itself does not define any macros, except for its include guard
-(`YOREL_YOMM2_CORE_INCLUDED`).
+main features of `core`.
 
 The header consumes two macros:
 * `NDEBUG`: if defined, no checks are performed during method calls. This
   delivers a performance close to normal virtual function calls.
 * `YOMM2_TRACE`: controls tracing. This feature is, at the moment, not
   documented.
+* YOMM2_SHARED: if defined, the library runtime is in a shared library or DLL.
+
+The header defines only the following macros:
+* an include guard (`YOREL_YOMM2_CORE_INCLUDED`).
+* *iff* YOMM2_SHARED is defined, a `yOMM2_API` macro.
 
 ### `<yorel/yomm2/symbols.hpp>`
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,12 @@
 
 option(YOMM2_SHARED "Build yomm2 as a shared library" OFF)
 if(YOMM2_SHARED)
+  message(STATUS "Building a shared library")
   add_library(yomm2 SHARED)
   if(NOT WIN32)
     target_compile_options(yomm2 PRIVATE -fvisibility=hidden)
   endif()
   target_compile_definitions(yomm2
-    PRIVATE -DBUILDING_YOMM2=1
     PUBLIC -DYOMM2_SHARED=1
   )
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,21 @@
 # See accompanying file LICENSE_1_0.txt
 # or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-add_library(yomm2 STATIC yomm2.cpp)
+option(YOMM2_SHARED "Build yomm2 as a shared library" OFF)
+if(YOMM2_SHARED)
+  add_library(yomm2 SHARED)
+  if(NOT WIN32)
+    target_compile_options(yomm2 PRIVATE -fvisibility=hidden)
+  endif()
+  target_compile_definitions(yomm2
+    PRIVATE -DBUILDING_YOMM2=1
+    PUBLIC -DYOMM2_SHARED=1
+  )
+else()
+    add_library(yomm2 STATIC)
+endif()
+
+target_sources(yomm2 PRIVATE yomm2.cpp)
 
 target_include_directories(yomm2 PUBLIC
   $<BUILD_INTERFACE:${YOMM2_SOURCE_DIR}/include>

--- a/src/yomm2.cpp
+++ b/src/yomm2.cpp
@@ -37,6 +37,10 @@ namespace yorel {
 namespace yomm2 {
 namespace detail {
 
+// export vtable
+void method_info::install_hash_factors(runtime&) {
+}
+
 std::ostream* logs;
 unsigned trace_flags;
 

--- a/src/yomm2.cpp
+++ b/src/yomm2.cpp
@@ -25,10 +25,20 @@
 #include <vector>        // for vector, vector<>:...
 
 #if defined(YOMM2_TRACE) && (YOMM2_TRACE & 1) || !defined(NDEBUG)
-#include <iostream>
+    #include <iostream>
 #endif
 
 #include <boost/dynamic_bitset/dynamic_bitset.hpp> // for operator<<, dynam...
+
+#if defined(YOMM2_SHARED)
+    #if defined(_WIN32)
+        #define yOMM2_API __declspec(dllexport)
+    #else
+        #define yOMM2_API __attribute__((__visibility__("default")))
+    #endif
+#else
+    #define yOMM2_API
+#endif
 
 #include <yorel/yomm2.hpp>
 #include <yorel/yomm2/runtime.hpp>


### PR DESCRIPTION
* Support shared library builds of yomm2 via CMake option `YOMM2_SHARED`
* If shared library build is on, force hidden visibility on *nix which greatly reduces .so size