### PR TITLE
Workaround on finding Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Find Boost dependency
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(cmake/find_or_download_package.cmake)
-find_or_download_package(Boost INSTALL_WITH_YOMM)
+find_package(Boost 1.74 QUIET)
+if(NOT TARGET Boost::headers)
+  find_or_download_package(Boost INSTALL_WITH_YOMM)
+endif()
 message(STATUS "Using Boost libraries from ${Boost_INCLUDE_DIRS}")
 
 if(NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug") AND (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))


### PR DESCRIPTION
This would be a workaround to #43. I wanted to do a clean-up and a full replacement of in-build install via https://github.com/boostorg/cmake, but I faced some incompatibility: it is not offering a valid `Boost::headers` target (each lib has to be linked `Boost::mp11`, CMake complains the dependent target `boost_headers` is not exported, FetchContent_Declare on Windows is slow.

In absence of valid full replacement, I propose this minor change to check for system/user provided Boost first before trying to deal with it as before.