### PR TITLE
CMake: set explicit transitive requirements on C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ install(EXPORT YOMM2Targets
 )
 # Configure package config (tells using code about dependencies)
 configure_package_config_file(
-  cmake/Config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/YOMM2Config.cmake
+  cmake/YOMM2Config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/YOMM2Config.cmake
   INSTALL_DESTINATION lib/cmake/YOMM2
 )
 # Copy config files to install directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug") AND (CMAKE_COMPILER_IS_GNUCXX OR
 endif()
 
 if(MSVC)
-  add_compile_definitions(-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS)
+  add_compile_definitions(_SCL_SECURE_NO_WARNINGS _CRT_SECURE_NO_WARNINGS)
   add_compile_options(/EHsc /FAs)
 endif()
 

--- a/cmake/YOMM2Config.cmake.in
+++ b/cmake/YOMM2Config.cmake.in
@@ -1,3 +1,5 @@
+@PACKAGE_INIT@
+
 include(CMakeFindDependencyMacro)
 
 # Tell library users about the Boost dependency
@@ -5,3 +7,5 @@ find_dependency(Boost 1.74 REQUIRED)
 
 # Add the targets file
 include("${CMAKE_CURRENT_LIST_DIR}/YOMM2Targets.cmake")
+
+check_required_components(YOMM2) 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ if(YOMM2_SHARED)
     PUBLIC $<TARGET_PROPERTY:Boost::headers,INTERFACE_INCLUDE_DIRECTORIES>
   )
   target_link_libraries(yomm2 PUBLIC Boost::headers)
+  target_compile_features(yomm2 PUBLIC cxx_std_17)
   if (${YOMM2_CHECK_ABI_COMPATIBILITY})
     message(STATUS "type: ${CMAKE_BUILD_TYPE} FLAGS: ${CMAKE_CXX_FLAGS_RELEASE}")
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -42,6 +43,7 @@ else()
     $<INSTALL_INTERFACE:include>
   )
   target_link_libraries(yomm2 INTERFACE Boost::headers)
+  target_compile_features(yomm2 INTERFACE cxx_std_17)
 endif()
 
 install(TARGETS yomm2

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ if(YOMM2_SHARED)
   if(NOT WIN32)
     target_compile_options(yomm2 PRIVATE -fvisibility=hidden)
   endif()
-  target_compile_definitions(yomm2 PUBLIC -DYOMM2_SHARED=1)
+  target_compile_definitions(yomm2 PUBLIC YOMM2_SHARED=1)
   target_include_directories(
     yomm2 PUBLIC
     $<BUILD_INTERFACE:${YOMM2_SOURCE_DIR}/include>


### PR DESCRIPTION
and a bit of cleanup on definitions and the CMake config file