### PR TITLE
fix potential class/struct odr violations, and fix 32-bit shift

### DIFF
--- a/include/yorel/yomm2/policies/core.hpp
+++ b/include/yorel/yomm2/policies/core.hpp
@@ -77,7 +77,7 @@ struct domain {};
 } // namespace detail
 
 template<class Class, class Policy>
-struct virtual_ptr;
+class virtual_ptr;
 
 template<typename T>
 struct virtual_;

--- a/include/yorel/yomm2/policies/fast_perfect_hash.hpp
+++ b/include/yorel/yomm2/policies/fast_perfect_hash.hpp
@@ -140,7 +140,7 @@ void fast_perfect_hash<Policy>::hash_initialize(
     hash_search_error error;
     error.attempts = total_attempts;
     // error.duration = std::chrono::steady_clock::now() - start_time;
-    error.buckets = 1 << M;
+    error.buckets = size_t(1) << M;
 
     if constexpr (has_facet<Policy, error_handler>) {
         Policy::error(error_type(error));

--- a/include/yorel/yomm2/policy.hpp
+++ b/include/yorel/yomm2/policy.hpp
@@ -95,20 +95,20 @@ struct yOMM2_API_gcc debug
           backward_compatible_error_handler<debug>> {};
 
 #if defined(_MSC_VER) && !defined(yOMM2_DLL)
-extern template class __declspec(dllimport) basic_domain<debug_shared>;
-extern template class __declspec(dllimport) vptr_vector<debug_shared>;
-extern template class __declspec(dllimport)
+extern template struct __declspec(dllimport) basic_domain<debug_shared>;
+extern template struct __declspec(dllimport) vptr_vector<debug_shared>;
+extern template struct __declspec(dllimport)
 vectored_error<debug_shared, backward_compatible_error_handler<debug_shared>>;
-extern template class __declspec(dllimport) fast_perfect_hash<debug_shared>;
-extern template class __declspec(dllimport) checked_perfect_hash<debug_shared>;
-extern template class __declspec(dllimport)
+extern template struct __declspec(dllimport) fast_perfect_hash<debug_shared>;
+extern template struct __declspec(dllimport) checked_perfect_hash<debug_shared>;
+extern template struct __declspec(dllimport)
 basic_trace_output<debug_shared, detail::ostderr>;
-extern template class __declspec(dllimport)
+extern template struct __declspec(dllimport)
 basic_error_output<debug_shared, detail::ostderr>;
-extern template class __declspec(dllimport) checked_perfect_hash<debug_shared>;
-extern template class __declspec(dllimport)
+extern template struct __declspec(dllimport) checked_perfect_hash<debug_shared>;
+extern template struct __declspec(dllimport)
 backward_compatible_error_handler<debug_shared>;
-extern template class __declspec(dllimport) basic_policy<
+extern template struct __declspec(dllimport) basic_policy<
     debug_shared, vptr_vector<debug_shared>, std_rtti,
     checked_perfect_hash<debug_shared>, basic_error_output<debug_shared>,
     basic_trace_output<debug_shared>,

--- a/src/yomm2.cpp
+++ b/src/yomm2.cpp
@@ -23,17 +23,17 @@ namespace policy {
 
 //std::vector<type_id> checked_perfect_hash<debug_shared>::control;
 
-template class yOMM2_API_msc basic_domain<debug_shared>;
-template class yOMM2_API_msc vptr_vector<debug_shared>;
-template class yOMM2_API_msc basic_indirect_vptr<debug_shared>;
-template class yOMM2_API_msc vectored_error<
+template struct yOMM2_API_msc basic_domain<debug_shared>;
+template struct yOMM2_API_msc vptr_vector<debug_shared>;
+template struct yOMM2_API_msc basic_indirect_vptr<debug_shared>;
+template struct yOMM2_API_msc vectored_error<
     debug_shared, backward_compatible_error_handler<debug_shared>>;
-template class yOMM2_API_msc backward_compatible_error_handler<debug_shared>;
-template class yOMM2_API_msc fast_perfect_hash<debug_shared>;
-template class yOMM2_API_msc checked_perfect_hash<debug_shared>;
-template class yOMM2_API_msc basic_error_output<debug_shared>;
-template class yOMM2_API_msc basic_trace_output<debug_shared>;
-template class yOMM2_API_msc basic_policy<
+template struct yOMM2_API_msc backward_compatible_error_handler<debug_shared>;
+template struct yOMM2_API_msc fast_perfect_hash<debug_shared>;
+template struct yOMM2_API_msc checked_perfect_hash<debug_shared>;
+template struct yOMM2_API_msc basic_error_output<debug_shared>;
+template struct yOMM2_API_msc basic_trace_output<debug_shared>;
+template struct yOMM2_API_msc basic_policy<
     debug_shared, std_rtti, checked_perfect_hash<debug_shared>,
     basic_error_output<debug_shared>, basic_trace_output<debug_shared>,
     backward_compatible_error_handler<debug_shared>>;


### PR DESCRIPTION
Two commits in this PR:

* Fix potential ODR violations from the same types declared as class or struct. While it's true that the Itanium ABI, does not distinguish between the two, other ABI-s might, and MSVC's does. In rare cases this may lead to crazy bugs.
* Fix a 32-bit shift: `1 << M` is a 32-bit shift. So, even though `M` and `buckets` will be 64-bit (`size_t`) on a x64 system, when `M` is 32 or more, UB will ensue.
